### PR TITLE
bumped statsderl dependency to v0.3.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-  {statsderl, "0\.3\.2",
-    {git, "https://github.com/lpgauth/statsderl.git", {tag, "0.3.2"}}}
+  {statsderl, "0\.3\.4",
+    {git, "https://github.com/lpgauth/statsderl.git", {tag, "v0.3.4"}}}
  ]}.


### PR DESCRIPTION
We depend on some new features of statsderl, so we've been using a fork of vmstats recently. Since statsderl's API has not changed since 0.3.2 I see no reason not to bring vmstats up to date with it. Cheers
