### PR TITLE
Configurable lists of memory stats to collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The following is a list of the possible options for the configuration of the
   * `key_separator` - (char) used as a separator between the parts of metric keys. Defaults to `$.`.
   * `interval` - (integer) the time (in milliseconds) between metric gatherings. Defaults to `1000` (1s).
   * `sched_time` - (boolean) whether to gather statistics about scheduler wall time. Defaults to `true`.
+  * `memory_fields` - (proplist of metric and key) what fields to collect statistics for.
+                      Available fields can be found [here](http://erlang.org/doc/man/erlang.html#memory-1).
+                      Default list is `[{total, total}, {processes_used, procs_used}, {atom_used, atom_used}, {binary, binary}, {ets, ets}]`.
 
 ### `vmstats_sink` behaviour
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The following is a list of the possible options for the configuration of the
   * `key_separator` - (char) used as a separator between the parts of metric keys. Defaults to `$.`.
   * `interval` - (integer) the time (in milliseconds) between metric gatherings. Defaults to `1000` (1s).
   * `sched_time` - (boolean) whether to gather statistics about scheduler wall time. Defaults to `true`.
-  * `memory_fields` - (proplist of metric and key) what fields to collect statistics for.
-                      Available fields can be found [here](http://erlang.org/doc/man/erlang.html#memory-1).
-                      Default list is `[{total, total}, {processes_used, procs_used}, {atom_used, atom_used}, {binary, binary}, {ets, ets}]`.
+  * `memory_metrics` - (proplist of metric and key) what fields to collect statistics for.
+                       Available fields can be found [here](http://erlang.org/doc/man/erlang.html#memory-1).
+                       Default list is `[{total, total}, {processes_used, procs_used}, {atom_used, atom_used}, {binary, binary}, {ets, ets}]`.
 
 ### `vmstats_sink` behaviour
 

--- a/src/vmstats.app.src
+++ b/src/vmstats.app.src
@@ -12,7 +12,14 @@
     {base_key, "vmstats"},
     {interval, 1000}, % in milliseconds
     {key_separator, $.},
-    {sched_time, true}
+    {sched_time, true},
+    {memory_metrics, [
+      {total, total},
+      {processes_used, procs_used},
+      {atom_used, atom_used},
+      {binary, binary},
+      {ets, ets}
+    ]}
   ]},
   {maintainers, ["Fred Hebert"]},
   {licenses, ["BSD-3"]},

--- a/test/vmstats_server_tests.erl
+++ b/test/vmstats_server_tests.erl
@@ -5,6 +5,14 @@ timer_500ms_test() ->
     application:set_env(vmstats, interval, 500),
     application:set_env(vmstats, key_separator, $.),
     application:set_env(vmstats, sched_time, false),
+    application:set_env(vmstats, memory_metrics, [
+      {total, total},
+      {processes_used, procs_used},
+      {atom_used, atom_used},
+      {binary, binary},
+      {ets, ets}
+    ]),
+
     Key = "key",
     sample_sink:start_link(),
     {ok, Pid} = vmstats_server:start_link(sample_sink, Key),


### PR DESCRIPTION
### WHAT
Makes the memory field stat collection configurable. 

### NOTE
One thing to note is that the `proc_used` field will not be backwards compatible and people will need to change their graphs, etc. There are ways to go around this but they all seem hacky. Let me know what you think.