### PR TITLE
Added atom_count metric

### DIFF
--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -72,7 +72,7 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     try
         Sink:collect(gauge, [K, "atom_count"], erlang:system_info(atom_count))
     catch
-        _:_ -> ok
+        _:badarg -> ok
     end,
 
     %% Messages in queues

--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -19,7 +19,7 @@
                 timer_ref :: reference(),
                 interval :: integer(), % milliseconds
                 prev_io :: {In::integer(), Out::integer()},
-                prev_gc :: {GCs::integer(), Words::integer(), 0}}).
+                prev_gc :: {GCs::integer(), Words::integer()}}).
 %%% INTERFACE
 start_link(Sink, BaseKey) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, {Sink, BaseKey}, []).
@@ -67,6 +67,13 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     %% Ports
     Sink:collect(gauge, [K,"port_count"], erlang:system_info(port_count)),
     Sink:collect(gauge, [K,"port_limit"], erlang:system_info(port_limit)),
+
+    %% Atom count, working only on Erlang 20+
+    try
+        Sink:collect(gauge, [K, "atom_count"], erlang:system_info(atom_count))
+    catch
+        _:_ -> ok
+    end,
 
     %% Messages in queues
     TotalMessages = lists:foldl(


### PR DESCRIPTION
Added `atom_count` metric, as discussed in #16. As it only works on Erlang 20+ and I didn't find a better way to determine whether the stat is supported or not, I wrapped the call with try/catch. Tested on both 19 and 20 and it works on both.

On line 20 I also noticed the `prev_gc` in `state` record had an incorrect type, so I fixed that too.