### PR TITLE
Add support for OTP 21

### DIFF
--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -98,7 +98,7 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     case whereis(error_logger) of
         undefined -> ok ;
         Pid ->
-            {_, MQL} = process_info(whereis, message_queue_len),
+            {_, MQL} = process_info(Pid, message_queue_len),
             Sink:collect(gauge, [K,"error_logger_queue_len"], MQL)
     end,
 

--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -95,8 +95,12 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     Sink:collect(gauge, [K,"run_queue"], erlang:statistics(run_queue)),
 
     %% Error logger backlog (lower is better)
-    {_, MQL} = process_info(whereis(error_logger), message_queue_len),
-    Sink:collect(gauge, [K,"error_logger_queue_len"], MQL),
+    case whereis(error_logger) of
+        undefined -> ok ;
+        Pid ->
+            {_, MQL} = process_info(whereis, message_queue_len),
+            Sink:collect(gauge, [K,"error_logger_queue_len"], MQL)
+    end,
 
     collect_memory_stats(Sink, [K, "memory", KS], MM),
 

--- a/test/vmstats_server_tests.erl
+++ b/test/vmstats_server_tests.erl
@@ -1,7 +1,48 @@
 -module(vmstats_server_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-timer_500ms_test() ->
+-ifdef(OTP_RELEASE).
+-define(MATCH, [{"key.atom_count", _},
+         {"key.gc.count", _},
+         {"key.gc.words_reclaimed", _},
+         {"key.io.bytes_in", _},
+         {"key.io.bytes_out", _},
+         {"key.memory.atom_used", _},
+         {"key.memory.binary", _},
+         {"key.memory.ets", _},
+         {"key.memory.procs_used", _},
+         {"key.memory.total", _},
+         {"key.messages_in_queues", _},
+         {"key.modules", _},
+         {"key.port_count", _},
+         {"key.port_limit", _},
+         {"key.proc_count", _},
+         {"key.proc_limit", _},
+         {"key.reductions", _},
+         {"key.run_queue", _}]).
+-else.
+-define(MATCH, [{"key.atom_count", _},
+         {"key.error_logger_queue_len", _},
+         {"key.gc.count", _},
+         {"key.gc.words_reclaimed", _},
+         {"key.io.bytes_in", _},
+         {"key.io.bytes_out", _},
+         {"key.memory.atom_used", _},
+         {"key.memory.binary", _},
+         {"key.memory.ets", _},
+         {"key.memory.procs_used", _},
+         {"key.memory.total", _},
+         {"key.messages_in_queues", _},
+         {"key.modules", _},
+         {"key.port_count", _},
+         {"key.port_limit", _},
+         {"key.proc_count", _},
+         {"key.proc_limit", _},
+         {"key.reductions", _},
+         {"key.run_queue", _}]).
+-endif.
+
+setup() ->
     application:set_env(vmstats, interval, 500),
     application:set_env(vmstats, key_separator, $.),
     application:set_env(vmstats, sched_time, false),
@@ -17,54 +58,28 @@ timer_500ms_test() ->
     sample_sink:start_link(),
     {ok, Pid} = vmstats_server:start_link(sample_sink, Key),
     unlink(Pid),
-    timer:sleep(750),
-    %% First match works
-    ?assertMatch(
-        [{"key.atom_count", _},
-         {"key.error_logger_queue_len", _},
-         {"key.gc.count", _},
-         {"key.gc.words_reclaimed", _},
-         {"key.io.bytes_in", _},
-         {"key.io.bytes_out", _},
-         {"key.memory.atom_used", _},
-         {"key.memory.binary", _},
-         {"key.memory.ets", _},
-         {"key.memory.procs_used", _},
-         {"key.memory.total", _},
-         {"key.messages_in_queues", _},
-         {"key.modules", _},
-         {"key.port_count", _},
-         {"key.port_limit", _},
-         {"key.proc_count", _},
-         {"key.proc_limit", _},
-         {"key.reductions", _},
-         {"key.run_queue", _}],
-        lists:sort([{lists:flatten(K), V} || {K, V} <- sample_sink:called()])
-    ),
-    timer:sleep(600),
-    exit(Pid, shutdown),
-    %% Done, we know it loops!
-    ?assertMatch(
-        [{"key.atom_count", _},
-         {"key.error_logger_queue_len", _},
-         {"key.gc.count", _},
-         {"key.gc.words_reclaimed", _},
-         {"key.io.bytes_in", _},
-         {"key.io.bytes_out", _},
-         {"key.memory.atom_used", _},
-         {"key.memory.binary", _},
-         {"key.memory.ets", _},
-         {"key.memory.procs_used", _},
-         {"key.memory.total", _},
-         {"key.messages_in_queues", _},
-         {"key.modules", _},
-         {"key.port_count", _},
-         {"key.port_limit", _},
-         {"key.proc_count", _},
-         {"key.proc_limit", _},
-         {"key.reductions", _},
-         {"key.run_queue", _}],
-        lists:sort([{lists:flatten(K), V} || {K, V} <- sample_sink:called()])
-    ),
-    ?assertEqual([], lists:sort(sample_sink:called())),
-    sample_sink:stop().
+    Pid.
+
+teardown(_) -> sample_sink:stop().
+
+get_values() ->
+    lists:sort([{lists:flatten(K), V} || {K, V} <- sample_sink:called()]).
+
+timer_500ms_test_() ->
+    {setup,
+     fun setup/0,
+     fun teardown/1,
+     fun(Pid) ->
+             [
+              {?LINE, fun() ->
+                              timer:sleep(750),
+                              ?assertMatch(?MATCH, get_values())
+                      end},
+              {?LINE, fun() ->
+                              timer:sleep(600),
+                              exit(Pid, shutdown),
+                              ?assertMatch(?MATCH, get_values())
+                      end},
+              ?_assertEqual([], get_values())
+             ]
+     end}.

--- a/test/vmstats_server_tests.erl
+++ b/test/vmstats_server_tests.erl
@@ -71,15 +71,15 @@ timer_500ms_test_() ->
      fun teardown/1,
      fun(Pid) ->
              [
-              {?LINE, fun() ->
-                              timer:sleep(750),
-                              ?assertMatch(?MATCH, get_values())
-                      end},
-              {?LINE, fun() ->
-                              timer:sleep(600),
-                              exit(Pid, shutdown),
-                              ?assertMatch(?MATCH, get_values())
-                      end},
+              ?_test(begin
+                         timer:sleep(750),
+                         ?assertMatch(?MATCH, get_values())
+                     end),
+              ?_test(begin
+                         timer:sleep(600),
+                         exit(Pid, shutdown),
+                         ?assertMatch(?MATCH, get_values())
+                     end),
               ?_assertEqual([], get_values())
              ]
      end}.


### PR DESCRIPTION
This checks if `error_logger` is running and only if send metrics.

Close #20 