### PR TITLE
Add vmstats:child_spec/1 for external supervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,6 @@ specifies one function:
                   Value :: term()) -> ok.
 ```
 
-### Running as part of own supervision tree
-
-You can run `vmstats` as part of your own supervision tree instead of relying on
-additional application by adding result of `vmstats:child_spec(Sink, BaseKey)`
-to your supervisor. For explanation of arguments look into
-[Configuration](#Configuration) `sink` and `base_key` descriptions.
-
 ## I was basing myself on 'master' and stuff started breaking!
 
 That's because you should use tags for stable versions instead! The [changelog](CHANGELOG.md) should let you know what to expect.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ specifies one function:
                   Value :: term()) -> ok.
 ```
 
+### Running as part of own supervision tree
+
+You can run `vmstats` as part of your own supervision tree instead of relying on
+additional application by adding result of `vmstats:child_spec(Sink, BaseKey)`
+to your supervisor. For explanation of arguments look into
+[Configuration](#Configuration) `sink` and `base_key` descriptions.
+
 ## I was basing myself on 'master' and stuff started breaking!
 
 That's because you should use tags for stable versions instead! The [changelog](CHANGELOG.md) should let you know what to expect.

--- a/src/vmstats.erl
+++ b/src/vmstats.erl
@@ -3,7 +3,15 @@
 %%% over its lifetime, helping diagnose or prevent problems in the long run.
 -module(vmstats).
 -behaviour(application).
--export([start/2, stop/1]).
+-export([start/2, stop/1, child_spec/2]).
+
+child_spec(Sink, BaseKey) ->
+    {vmstats,
+     {vmstats_server, start_link, [Sink, BaseKey]},
+     permanent,
+     1000,
+     worker,
+     [vmstats_server]}.
 
 start(normal, []) ->
     {ok, Sink} = application:get_env(vmstats, sink),

--- a/src/vmstats_sup.erl
+++ b/src/vmstats_sup.erl
@@ -8,14 +8,9 @@
 start_link(Sink, BaseKey) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, [Sink, BaseKey]).
 
-init(Args) ->
+init([Sink, BaseKey]) ->
     %% The stats are mixed in for all nodes. Differentiate keys by node name
     %% is the only way to make sure stats won't be mixed for all different
     %% systems. Hopefully, you remember to name nodes when you start them!
-    ChildSpec = {vmstats,
-                 {vmstats_server, start_link, Args},
-                 permanent,
-                 1000,
-                 worker,
-                 [vmstats_server]},
+    ChildSpec = vmstats:child_spec(Sink, BaseKey),
     {ok, {{one_for_all,5,3600}, [ChildSpec]}}.


### PR DESCRIPTION
This will allow external supervisors to run vmstats as part of their
internal supervision tree.  This is useful due to fact that some sinks
can require some a priori setup, like opening socket connection to
external gatherer, ex. DataDogD.