### PR TITLE
Add vm_uptime function to vmstats

### DIFF
--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -94,6 +94,11 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     %% Queued up processes (lower is better)
     Sink:collect(gauge, [K,"run_queue"], erlang:statistics(run_queue)),
 
+    %% VN uptime stats.
+    Sink:collect(timing, [K, "vm_uptime"],
+                 erlang:element(1,
+                                erlang:statistics(wall_clock))),
+
     %% Error logger backlog (lower is better)
     case whereis(error_logger) of
         undefined -> ok ;

--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -95,8 +95,7 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     Sink:collect(gauge, [K,"run_queue"], erlang:statistics(run_queue)),
 
     %% Erlang VM uptime stats.
-    Sink:collect(timing, [K, "vm_uptime"], erlang:element(1,
-                                      erlang:statistics(walll_clock))),
+    Sink:collect(timing, [K, "vm_uptime"], erlang:element(1, erlang:statistics(wall_clock))),
 
     %% Error logger backlog (lower is better)
     case whereis(error_logger) of

--- a/src/vmstats_server.erl
+++ b/src/vmstats_server.erl
@@ -94,10 +94,9 @@ handle_info({timeout, R, ?TIMER_MSG}, S = #state{sink=Sink, key=K, key_separator
     %% Queued up processes (lower is better)
     Sink:collect(gauge, [K,"run_queue"], erlang:statistics(run_queue)),
 
-    %% VN uptime stats.
-    Sink:collect(timing, [K, "vm_uptime"],
-                 erlang:element(1,
-                                erlang:statistics(wall_clock))),
+    %% Erlang VM uptime stats.
+    Sink:collect(timing, [K, "vm_uptime"], erlang:element(1,
+                                      erlang:statistics(walll_clock))),
 
     %% Error logger backlog (lower is better)
     case whereis(error_logger) of


### PR DESCRIPTION
Further to #24, I propose this PR to make the BEAM VM uptime available.

Commit message:
This commit adds a function for making the current uptime of the BEAM
VM (using `wall_clock`) available. Currently, the type is `timing`, and
the unit of measurement is in milliseconds.