### PR TITLE
Add missing field value in tests

### DIFF
--- a/test/sample_sink.erl
+++ b/test/sample_sink.erl
@@ -3,10 +3,9 @@
 
 -export([collect/3, start_link/0, called/0, stop/0]).
 
-collect(counter, Key, Value) ->
-    call({counter, Key, Value});
-collect(gauge, Key, Value) ->
-    call({gauge, Key, Value}).
+collect(Type, Key, Value) when Type =:= timing; Type =:= gauge; Type =:= counter ->
+    K = lists:flatten(Key),
+    call({store, K, Value}).
 
 start_link() ->
     spawn_link(fun() -> init() end).
@@ -21,10 +20,7 @@ init() ->
 
 loop(Stack) ->
     receive
-        {From, {counter, K, D}} ->
-            reply(From, ok),
-            loop([{K,D}|Stack]);
-        {From, {gauge, K, D}} ->
+        {From, {store, K, D}} ->
             reply(From, ok),
             loop([{K,D}|Stack]);
         {From, called} ->

--- a/test/vmstats_server_tests.erl
+++ b/test/vmstats_server_tests.erl
@@ -19,7 +19,8 @@
          {"key.proc_count", _},
          {"key.proc_limit", _},
          {"key.reductions", _},
-         {"key.run_queue", _}]).
+         {"key.run_queue", _},
+         {"key.vm_uptime", _}]).
 -else.
 -define(MATCH, [{"key.atom_count", _},
          {"key.error_logger_queue_len", _},
@@ -39,7 +40,8 @@
          {"key.proc_count", _},
          {"key.proc_limit", _},
          {"key.reductions", _},
-         {"key.run_queue", _}]).
+         {"key.run_queue", _},
+         {"key.vm_uptime", _}]).
 -endif.
 
 setup() ->


### PR DESCRIPTION
- `key.vm_uptime` was not present
- `timing` metric type was not present